### PR TITLE
Fixed failing tests in MacOS

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -146,8 +146,9 @@ default_category = no-category"""
     @mock.patch("sys.stderr.write")
     def test_verbose(self, mocked_stderr):
         self.cli_run("print --verbose")
-        self.assertTrue(mocked_stderr.call_args_list[0][0][0].endswith(
-            "Loading custom config from {}".format(TEST_CONFIG_FILEPATH)))
+        self.assertIn(
+            "Loading custom config from {}".format(TEST_CONFIG_FILEPATH),
+            mocked_stderr.call_args_list[0][0][0])
 
     @mock.patch("financeager.offline.OFFLINE_FILEPATH",
                 "/tmp/financeager-test-offline.json")

--- a/test/test_httprequests.py
+++ b/test/test_httprequests.py
@@ -48,7 +48,7 @@ class HttpRequestProxyTestCase(unittest.TestCase):
 
         error_message = cm.exception.args[0]
         self.assertTrue(error_message.startswith("Error sending request: "))
-        self.assertIn("Name or service not known", error_message)
+        self.assertIn("NewConnectionError", error_message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #36.

Should make the two failing tests more robust.