### PR TITLE
Renamed the `print` and `list` commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Client-side communication interface is abstracted in the Client class.
 - Various test framework enhancements.
 - [Incompatible] The URL endpoint for copying entries is changed from /periods/copy to /copy. (PR#32)
+- [Incompatible] The `list` command has been renamed to `periods`. (#38)
+- [Incompatible] The `print` command has been renamed to `list`. (#38)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -87,24 +87,24 @@ In any case, you're all set up! See the next section about the available client 
 
 ### Command line client
 
-    usage: financeager [-h] {add,get,rm,update,copy,print,list} ...
+    usage: financeager [-h] [-V] {add,get,rm,update,copy,list,periods} ...
 
     optional arguments:
       -h, --help            show this help message and exit
       -V, --version         display version info and exit
 
     subcommands:
-      {add,get,rm,update,copy,print,list}
+      {add,get,rm,update,copy,list,periods}
                             list of available subcommands
         add                 add an entry to the database
         get                 show information about single entry
         rm                  remove an entry from the database
         update              update one or more fields of an database entry
         copy                copy an entry from one period to another
-        print               show the period database
-        list                list all databases
+        list                list all entries in the period database
+        periods             lists all period databases
 
-On the client side, `financeager` provides the following commands to interact with the backend: `add`, `update`, `rm`, `get`, `print`, `list`, `copy`.
+On the client side, `financeager` provides the following commands to interact with the backend: `add`, `update`, `rm`, `get`, `list`, `periods`, `copy`.
 
 *Add* earnings (no/positive sign) and expenses (negative sign) to the database:
 
@@ -119,11 +119,11 @@ Category and date can be optionally specified. They default to None and the curr
 
 If not specified, the start date defaults to the current date and the end date to the last day of the database's year.
 
-Did you make a mistake when adding a new entry? *Update* one or more fields by calling the 'update' command with the entry's ID and the respective corrected fields:
+Did you make a mistake when adding a new entry? *Update* one or more fields by calling the `update` command with the entry's ID and the respective corrected fields:
 
     > financeager update 1 --name "McKing Burgers" --value -18.59
 
-*Remove* an entry by specifying its ID (visible in the output of the `print` command). This removes the `burgers` entry:
+*Remove* an entry by specifying its ID (visible in the output of the `list` command). This removes the `burgers` entry:
 
     > financeager rm 1
 
@@ -133,7 +133,7 @@ This would remove the recurrent rent entries (ID is also 1 because standard and 
 
 Show a side-by-side *overview* of earnings and expenses (filter by date/category/name/value by passing the `--filters` option, e.g. `--filters category=food` to show entries in the categories `food`)
 
-    > financeager print
+    > financeager list
 
                    Earnings               |                Expenses
     Name               Value    Date  ID  | Name               Value    Date  ID
@@ -159,7 +159,7 @@ Detailed information is available from
 
 You can turn on printing debug messages to the terminal using the `--verbose` option, e.g.
 
-    > financeager print --verbose
+    > financeager list --verbose
 
 You can find a log of interactions at `~/.local/share/financeager/log` (on both the client machine and the server).
 
@@ -243,11 +243,11 @@ Please adhere to test-driven development, if possible: When adding a feature, or
 ### Ideas
 
 - [ ] experiment with urwid for building TUI or remi for HTML-based GUI
-- [ ] support querying of standard/recurrent table with `print`
+- [ ] support querying of standard/recurrent table with `list`
 - [x] return element data as response to add/copy/update request
 - [ ] support passing multiple elements IDs to update/rm/copy/get (maybe together with asynchronous HTTP requests)
 - [ ] extended period names (something along `2018-personal`)
-- [ ] support `print` at date other than today
+- [ ] support `list` at date other than today
 
 ### Discarded ideas
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In any case, you're all set up! See the next section about the available client 
         update              update one or more fields of an database entry
         copy                copy an entry from one period to another
         list                list all entries in the period database
-        periods             lists all period databases
+        periods             list all period databases
 
 On the client side, `financeager` provides the following commands to interact with the backend: `add`, `update`, `rm`, `get`, `list`, `periods`, `copy`.
 

--- a/financeager/cli.py
+++ b/financeager/cli.py
@@ -241,31 +241,32 @@ least a frequency, start date and end date are optional. Default:
         default=None,
         help="Table to copy the entry from/to. Default: 'standard'.")
 
-    print_parser = subparsers.add_parser(
-        "print", help="show the period database")
-    print_parser.add_argument(
+    list_parser = subparsers.add_parser(
+        "list", help="list all entries in the period database")
+    list_parser.add_argument(
         "-f",
         "--filters",
         default=None,
         nargs="+",
         help="filter for name, "
         "date and/or category substring, e.g. name=beer category=groceries")
-    print_parser.add_argument(
+    list_parser.add_argument(
         "-s",
         "--stacked-layout",
         action="store_true",
         help="if true, display earnings and expenses in stacked layout, "
         "otherwise side-by-side")
-    print_parser.add_argument(
+    list_parser.add_argument(
         "--entry-sort",
         choices=["name", "value", "date", "eid"],
         default=financeager.DEFAULT_BASE_ENTRY_SORT_KEY)
-    print_parser.add_argument(
+    list_parser.add_argument(
         "--category-sort",
         choices=["name", "value"],
         default=financeager.DEFAULT_CATEGORY_ENTRY_SORT_KEY)
 
-    list_parser = subparsers.add_parser("list", help="list all databases")
+    periods_parser = subparsers.add_parser(
+        "periods", help="lists all period databases")
 
     # Add common options to subparsers
     for subparser in subparsers.choices.values():
@@ -279,7 +280,7 @@ least a frequency, start date and end date are optional. Default:
             action="store_true",
             help="Be verbose about internal workings")
 
-        if subparser not in [list_parser, copy_parser]:
+        if subparser not in [periods_parser, copy_parser]:
             subparser.add_argument(
                 "-p", "--period", help="name of period to modify or query")
 

--- a/financeager/cli.py
+++ b/financeager/cli.py
@@ -266,7 +266,7 @@ least a frequency, start date and end date are optional. Default:
         default=financeager.DEFAULT_CATEGORY_ENTRY_SORT_KEY)
 
     periods_parser = subparsers.add_parser(
-        "periods", help="lists all period databases")
+        "periods", help="list all period databases")
 
     # Add common options to subparsers
     for subparser in subparsers.choices.values():

--- a/financeager/communication.py
+++ b/financeager/communication.py
@@ -80,7 +80,7 @@ class Client:
         """
         # Extract formatting options; irrelevant, event confusing for Server
         formatting_options = {}
-        if command == "print":
+        if command == "list":
             for option in ["stacked_layout", "entry_sort", "category_sort"]:
                 formatting_options[option] = params.pop(option)
 

--- a/financeager/httprequests.py
+++ b/financeager/httprequests.py
@@ -48,13 +48,13 @@ class _Proxy:
 
         kwargs = dict(auth=auth, timeout=DEFAULT_TIMEOUT)
 
-        if command == "print":
+        if command == "list":
             # Correctly send filters; allowing for server-side deserialization
             kwargs["json"] = json.dumps(data)
         else:
             kwargs["json"] = data or None
 
-        if command == "print":
+        if command == "list":
             url = period_url
             function = requests.get
         elif command == "rm":
@@ -63,7 +63,7 @@ class _Proxy:
         elif command == "add":
             url = period_url
             function = requests.post
-        elif command == "list":
+        elif command == "periods":
             url = base_url
             function = requests.post
         elif command == "copy":

--- a/financeager/resources.py
+++ b/financeager/resources.py
@@ -73,14 +73,14 @@ class LogResource(Resource):
 
 class PeriodsResource(LogResource):
     def post(self):
-        return self.run_safely("list")
+        return self.run_safely("periods")
 
 
 class PeriodResource(LogResource):
     def get(self, period_name):
         args = json.loads(flask.request.json or "{}")
         return self.run_safely(
-            "print", error_code=400, period=period_name, **args)
+            "list", error_code=400, period=period_name, **args)
 
     def post(self, period_name):
         args = put_parser.parse_args()

--- a/financeager/server.py
+++ b/financeager/server.py
@@ -29,7 +29,7 @@ class Server:
         logger.debug("Running '{}' with {}".format(command, kwargs))
 
         try:
-            if command == "list":
+            if command == "periods":
                 return {"periods": [p._name for p in self._periods.values()]}
             elif command == "copy":
                 return {"id": self._copy_entry(**kwargs)}
@@ -46,7 +46,7 @@ class Server:
                     response = {"id": period.add_entry(**kwargs)}
                 elif command == "rm":
                     response = {"id": period.remove_entry(**kwargs)}
-                elif command == "print":
+                elif command == "list":
                     response = {"elements": period.get_entries(**kwargs)}
                 elif command == "get":
                     response = {"element": period.get_entry(**kwargs)}

--- a/test/test_communication.py
+++ b/test/test_communication.py
@@ -53,18 +53,18 @@ Value   : -99.0
 Date    : {}
 Category: Clothes""".format(today()))
 
-    def test_list(self):
-        response = self.client.run("list")
+    def test_periods(self):
+        response = self.client.run("periods")
         self.assertEqual(response, "{}".format(date.today().year))
 
-    def test_print(self):
+    def test_list(self):
         formatting_options = dict(
             stacked_layout=False, entry_sort="name", category_sort="value")
-        response = self.client.run("print", **formatting_options)
+        response = self.client.run("list", **formatting_options)
         self.assertNotEqual("", response)
 
         response = self.client.run(
-            "print", filters={"date": "12-"}, **formatting_options)
+            "list", filters={"date": "12-"}, **formatting_options)
         self.assertEqual("", response)
 
     def test_stop(self):

--- a/test/test_httprequests.py
+++ b/test/test_httprequests.py
@@ -27,7 +27,7 @@ class HttpRequestProxyTestCase(unittest.TestCase):
                 "financeager.httprequests.requests.post",
                 side_effect=self.mock_post) as post_patch:
 
-            proxy.run("list")
+            proxy.run("periods")
 
             url = "{}{}".format(DEFAULT_HOST, PERIODS_TAIL)
             kwargs = {

--- a/test/test_offline.py
+++ b/test/test_offline.py
@@ -33,7 +33,7 @@ class AddTestCase(unittest.TestCase):
         self.assertEqual(element["value"], 111)
 
     def test_no_add(self):
-        self.assertFalse(add("print"))
+        self.assertFalse(add("list"))
 
     def test_no_recover(self):
         self.assertFalse(recover(None, offline_filepath=self.filepath))

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -20,8 +20,8 @@ class AddEntryToServerTestCase(unittest.TestCase):
     def test_period_name(self):
         self.assertEqual("0", self.server._periods["0"].name)
 
-    def test_list(self):
-        response = self.server.run("list")
+    def test_periods(self):
+        response = self.server.run("periods")
         self.assertListEqual(response["periods"], ["0"])
 
     def test_unknown_command(self):
@@ -45,7 +45,7 @@ class RecurrentEntryServerTestCase(unittest.TestCase):
 
     def test_recurrent_entries(self):
         elements = self.server.run(
-            "print", period=self.period,
+            "list", period=self.period,
             filters={"name": "rent"})["elements"]["recurrent"][self.entry_id]
         self.assertEqual(len(elements), 6)
 
@@ -95,7 +95,7 @@ class FindEntryServerTestCase(unittest.TestCase):
     def test_query_and_reset_response(self):
         category = CategoryEntry.DEFAULT_NAME
         response = self.server.run(
-            "print", period=self.period, filters={"category": category})
+            "list", period=self.period, filters={"category": category})
         self.assertGreater(len(response), 0)
         self.assertIsInstance(response, dict)
         self.assertIsInstance(response["elements"], dict)
@@ -111,7 +111,7 @@ class FindEntryServerTestCase(unittest.TestCase):
         self.assertEqual(response["id"], self.entry_id)
 
         response = self.server.run(
-            "print",
+            "list",
             period=self.period,
             filters={
                 "name": "Hiking boots",


### PR DESCRIPTION
+ `print` command renamed to `list`
+ `list` command renamed to `periods`
Part of fix for #11.

Will make a separate commit for renaming the `rm` command, so that it's easily revertable (if required). 