### PR TITLE
Issue #6: Support for webservice version in cli and flask api endpoint

### DIFF
--- a/financeager/cli.py
+++ b/financeager/cli.py
@@ -268,6 +268,9 @@ least a frequency, start date and end date are optional. Default:
     periods_parser = subparsers.add_parser(
         "periods", help="list all period databases")
 
+    service_parser = subparsers.add_parser(
+        "service", help="interact with the webservice")
+
     # Add common options to subparsers
     for subparser in subparsers.choices.values():
         subparser.add_argument(
@@ -280,7 +283,7 @@ least a frequency, start date and end date are optional. Default:
             action="store_true",
             help="Be verbose about internal workings")
 
-        if subparser not in [periods_parser, copy_parser]:
+        if subparser not in [periods_parser, copy_parser, service_parser]:
             subparser.add_argument(
                 "-p", "--period", help="name of period to modify or query")
 

--- a/financeager/communication.py
+++ b/financeager/communication.py
@@ -125,4 +125,8 @@ def _format_response(response, command, **listing_options):
     if periods is not None:
         return "\n".join([p for p in periods])
 
+    version = response.get("version")
+    if version is not None:
+        return version
+
     return ""

--- a/financeager/fflask.py
+++ b/financeager/fflask.py
@@ -8,7 +8,7 @@ from . import PERIODS_TAIL, COPY_TAIL, init_logger, setup_log_file_handler,\
     make_log_stream_handler_verbose
 from .server import Server
 from .resources import (PeriodsResource, PeriodResource, EntryResource,
-                        CopyResource)
+                        CopyResource, VersionResource)
 
 logger = init_logger(__name__)
 
@@ -63,5 +63,9 @@ def create_app(data_dir=None, config=None):
         EntryResource,
         "{}/<period_name>/<table_name>/<eid>".format(PERIODS_TAIL),
         resource_class_args=(server,))
+    api.add_resource(
+        VersionResource,
+        '/version'
+    )
 
     return app

--- a/financeager/httprequests.py
+++ b/financeager/httprequests.py
@@ -39,6 +39,7 @@ class _Proxy:
         eid_url = "{}/{}/{}".format(period_url,
                                     data.get("table_name") or DEFAULT_TABLE,
                                     data.get("eid"))
+        version_url = "{}/version".format(host)
 
         username = self.http_config.get("username")
         password = self.http_config.get("password")
@@ -75,6 +76,9 @@ class _Proxy:
         elif command == "update":
             url = eid_url
             function = requests.patch
+        elif command == "service":
+            url = version_url
+            function = requests.get
         else:
             raise ValueError("Unknown command: {}".format(command))
 

--- a/financeager/resources.py
+++ b/financeager/resources.py
@@ -4,6 +4,8 @@ import json
 import flask
 from flask_restful import Resource, reqparse
 
+from financeager import __version__
+
 from . import init_logger
 
 logger = init_logger(__name__)
@@ -120,3 +122,9 @@ class CopyResource(LogResource):
     def post(self):
         args = copy_parser.parse_args()
         return self.run_safely("copy", error_code=404, **args)
+
+
+class VersionResource(Resource):
+    def get(self):
+        val = {'version': __version__}
+        return val


### PR DESCRIPTION
This creates a new option to return the version of the webservice via a `service` command.

Note that I dropped the use of `--version` since the service endpoint only returns one thing at this point.