### PR TITLE
Remove warnings about unclosed file after running tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - `list --stacked-layout` displays total values of earnings and expenses (analogous to the output of bare `list`). (#35)
+- Database files are properly closed after test runs involving a Flask app. (#42)
 
 ## [v0.21] - 2019-08-19
 ### Added

--- a/financeager/fflask.py
+++ b/financeager/fflask.py
@@ -13,7 +13,7 @@ from .resources import (PeriodsResource, PeriodResource, EntryResource,
 logger = init_logger(__name__)
 
 
-def create_app(data_dir=None, config=None):
+def create_app(data_dir=None, config=None, return_server=False):
     """Create web app with RESTful API built from resources. The function is
     named such that the flask cli detects it as app factory method.
     The log file handler is set up very first.
@@ -63,5 +63,6 @@ def create_app(data_dir=None, config=None):
         EntryResource,
         "{}/<period_name>/<table_name>/<eid>".format(PERIODS_TAIL),
         resource_class_args=(server,))
-
+    if return_server:
+        return app, server
     return app

--- a/financeager/fflask.py
+++ b/financeager/fflask.py
@@ -63,5 +63,8 @@ def create_app(data_dir=None, config=None):
         EntryResource,
         "{}/<period_name>/<table_name>/<eid>".format(PERIODS_TAIL),
         resource_class_args=(server,))
+
+    # Assign attribute such that e.g. test_cli can access Server methods
     app._server = server
+
     return app

--- a/financeager/fflask.py
+++ b/financeager/fflask.py
@@ -13,7 +13,7 @@ from .resources import (PeriodsResource, PeriodResource, EntryResource,
 logger = init_logger(__name__)
 
 
-def create_app(data_dir=None, config=None, return_server=False):
+def create_app(data_dir=None, config=None):
     """Create web app with RESTful API built from resources. The function is
     named such that the flask cli detects it as app factory method.
     The log file handler is set up very first.
@@ -63,6 +63,5 @@ def create_app(data_dir=None, config=None, return_server=False):
         EntryResource,
         "{}/<period_name>/<table_name>/<eid>".format(PERIODS_TAIL),
         resource_class_args=(server,))
-    if return_server:
-        return app, server
+    app._server = server
     return app

--- a/financeager/httprequests.py
+++ b/financeager/httprequests.py
@@ -89,7 +89,7 @@ class _Proxy:
             try:
                 # Get further information about error (see Server.run)
                 error = response.json()["error"]
-            except (json.JSONDecodeError, KeyError):
+            except (json.JSONDecodeError, KeyError, ValueError):
                 error = "-"
 
             status_code = response.status_code

--- a/financeager/httprequests.py
+++ b/financeager/httprequests.py
@@ -89,7 +89,7 @@ class _Proxy:
             try:
                 # Get further information about error (see Server.run)
                 error = response.json()["error"]
-            except (json.JSONDecodeError, KeyError, ValueError):
+            except (json.JSONDecodeError, KeyError):
                 error = "-"
 
             status_code = response.status_code

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -239,8 +239,8 @@ host = http://{}
 
         def shutdown():
             from flask import request
-            request.environ.get("werkzeug.server.shutdown")()
             app._server.run('stop')
+            request.environ.get("werkzeug.server.shutdown")()
             return ""
 
         # For testing, add rule to shutdown Flask app

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -230,18 +230,17 @@ host = http://{}
         # created/interfering with logs on actual machine
         import financeager
         financeager.DATA_DIR = TEST_DATA_DIR
-        app, server = create_app(
+        app = create_app(
             data_dir=TEST_DATA_DIR,
             config={
                 "DEBUG": False,  # reloader can only be run in main thread
                 "SERVER_NAME": CliFlaskTestCase.HOST_IP,
-            },
-            return_server=True)
+            })
 
         def shutdown():
             from flask import request
             request.environ.get("werkzeug.server.shutdown")()
-            server.run('stop')
+            app._server.run('stop')
             return ""
 
         # For testing, add rule to shutdown Flask app

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -230,16 +230,18 @@ host = http://{}
         # created/interfering with logs on actual machine
         import financeager
         financeager.DATA_DIR = TEST_DATA_DIR
-        app = create_app(
+        app, server = create_app(
             data_dir=TEST_DATA_DIR,
             config={
                 "DEBUG": False,  # reloader can only be run in main thread
                 "SERVER_NAME": CliFlaskTestCase.HOST_IP,
-            })
+            },
+            return_server=True)
 
         def shutdown():
             from flask import request
             request.environ.get("werkzeug.server.shutdown")()
+            server.run('stop')
             return ""
 
         # For testing, add rule to shutdown Flask app


### PR DESCRIPTION
This is a pull request related to issue #39 . 
- What I have done is to prevent the stopping of web service without invoking closing the period database files. So I have made a keyword argument in **create_app** named `return_server ` to return server variable thus we can stop the server after `werkzeug.server.shutdown` is called (done in _test/test_cli.py_)

- At last, the ValueError is added in the exception list (file financeager/httprequests.py) so that the JSONDecodeError is got (Since simplejson.decoder.JSONDecodeError actually inherits from ValueError - https://stackoverflow.com/questions/8381193/handle-json-decode-error-when-nothing-returned) . This is done because of the error in test `test.test_cli.CliFlaskTestCase.test_communication_error`.