### PR TITLE
Fix typo, yaerly -> yearly

### DIFF
--- a/test/test_pocket.py
+++ b/test/test_pocket.py
@@ -519,7 +519,7 @@ class ValidationTestCase(unittest.TestCase):
                 {
                     "name": "rent",
                     "value": -400,
-                    "frequency": "yaerly",
+                    "frequency": "yearly",
                     "start": "2020-01-02",
                 }
             )


### PR DESCRIPTION
Found via `codespell -H -S *.svg`