### PR TITLE
Add CLI completion for --category option

### DIFF
--- a/financeager/__init__.py
+++ b/financeager/__init__.py
@@ -36,6 +36,7 @@ CACHE_DIR = platformdirs.user_cache_dir("financeager")
 LOG_DIR = os.path.join(CACHE_DIR, "log")
 
 CONFIG_FILEPATH = os.path.join(CONFIG_DIR, "config")
+CATEGORIES_CACHE_FILENAME = "categories.json"
 
 # Set up the package logger
 LOGGER = getLogger(__package__)

--- a/financeager/__init__.py
+++ b/financeager/__init__.py
@@ -36,7 +36,7 @@ CACHE_DIR = platformdirs.user_cache_dir("financeager")
 LOG_DIR = os.path.join(CACHE_DIR, "log")
 
 CONFIG_FILEPATH = os.path.join(CONFIG_DIR, "config")
-CATEGORIES_CACHE_FILENAME = "categories.json"
+CATEGORIES_CACHE_FILENAME = "categories"
 
 # Set up the package logger
 LOGGER = getLogger(__package__)

--- a/financeager/cli.py
+++ b/financeager/cli.py
@@ -2,7 +2,6 @@
 
 # PYTHON_ARGCOMPLETE_OK
 import argparse
-import json
 import os
 import sys
 import time
@@ -547,4 +546,4 @@ def _read_categories_for_cli_completion():
     if not os.path.exists(fp):
         return []
     with open(fp) as f:
-        return json.load(f)
+        return f.read().splitlines()

--- a/financeager/cli.py
+++ b/financeager/cli.py
@@ -542,8 +542,13 @@ specified, the -r option is ignored""",
 
 
 def _read_categories_for_cli_completion():
-    fp = os.path.join(financeager.CACHE_DIR, financeager.CATEGORIES_CACHE_FILENAME)
-    if not os.path.exists(fp):
+    try:
+        fp = os.path.join(financeager.CACHE_DIR, financeager.CATEGORIES_CACHE_FILENAME)
+        if not os.path.exists(fp):
+            return []
+        with open(fp) as f:
+            return f.read().splitlines()
+    except Exception as e:
+        logger.debug(str(e))
+        logger.warning("Error when trying to read category cache.")
         return []
-    with open(fp) as f:
-        return f.read().splitlines()

--- a/financeager/clients.py
+++ b/financeager/clients.py
@@ -1,6 +1,5 @@
 """Infrastructure for backend communication."""
 
-import json
 import os.path
 import traceback
 from collections import namedtuple
@@ -96,12 +95,11 @@ class LocalServerClient(Client):
         if command not in ["add", "remove", "update"]:
             return success
 
-        result = self.proxy.run("categories", pocket=params["pocket"])
-        with open(
-            os.path.join(financeager.CACHE_DIR, financeager.CATEGORIES_CACHE_FILENAME),
-            "w",
-        ) as f:
-            json.dump(result["categories"], f)
+        categories = self.proxy.run("categories", pocket=params["pocket"])["categories"]
+        fp = os.path.join(financeager.CACHE_DIR, financeager.CATEGORIES_CACHE_FILENAME)
+        with open(fp, "w") as f:
+            # The category cache is a line-separated list of names
+            f.write("\n".join(categories))
         return success
 
     def shutdown(self):

--- a/financeager/pocket.py
+++ b/financeager/pocket.py
@@ -534,6 +534,12 @@ class TinyDbPocket(Pocket):
 
         return self._search_all_tables(condition)
 
+    def get_categories(self):
+        """Return unique category names of the default table in alphabetical order."""
+        category_names = set(e["category"] for e in self._db.table(DEFAULT_TABLE).all())
+        category_names.discard(_DEFAULT_CATEGORY)
+        return sorted(category_names)
+
     def close(self):
         """Close underlying database."""
         self._db.close()

--- a/financeager/server.py
+++ b/financeager/server.py
@@ -54,6 +54,8 @@ class Server:
                     response = {"element": pd.get_entry(**kwargs)}
                 elif command == "update":
                     response = {"id": pd.update_entry(**kwargs)}
+                elif command == "categories":
+                    response = {"categories": pd.get_categories()}
                 else:
                     response = {"error": f"Server: unknown command '{command}'"}
                 return response

--- a/test/test_pocket.py
+++ b/test/test_pocket.py
@@ -216,6 +216,25 @@ class TinyDbPocketStandardEntryTestCase(unittest.TestCase):
             value="hundred",
         )
 
+    def test_get_categories(self):
+        # Table has one element with default category
+        self.assertEqual(len(self.pocket.get_entries()[DEFAULT_TABLE]), 1)
+        self.assertEqual(self.pocket.get_categories(), [])
+        self.pocket.remove_entry(eid=self.eid)
+        self.assertEqual(self.pocket.get_categories(), [])
+
+        category = "Groceries"
+        self.pocket.add_entry(name="Apple", value=-5, category=category)
+        self.assertEqual(self.pocket.get_categories(), [category.lower()])
+        self.pocket.add_entry(name="Pear", value=-3, category=category)
+        self.assertEqual(self.pocket.get_categories(), [category.lower()])
+
+        another_category = "Car"
+        self.pocket.add_entry(name="Petrol", value=-30, category=another_category)
+        self.assertEqual(
+            self.pocket.get_categories(), [another_category.lower(), category.lower()]
+        )
+
     def tearDown(self):
         self.pocket.close()
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -13,19 +13,23 @@ from financeager import (
 
 
 class AddEntryToServerTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.server = server.Server()
-        cls.server.run(
-            "add", name="Hiking boots", value=-111.11, category="outdoors", pocket="0"
+    def setUp(self):
+        self.server = server.Server()
+        self.pocket = "0"
+        self.server.run(
+            "add",
+            name="Hiking boots",
+            value=-111.11,
+            category="outdoors",
+            pocket=self.pocket,
         )
 
     def test_pocket_name(self):
-        self.assertEqual("0", self.server._pockets["0"].name)
+        self.assertEqual(self.pocket, self.server._pockets[self.pocket].name)
 
     def test_pockets(self):
         response = self.server.run("pockets")
-        self.assertListEqual(response["pockets"], ["0"])
+        self.assertListEqual(response["pockets"], [self.pocket])
 
     def test_unknown_command(self):
         response = self.server.run("peace")

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -35,6 +35,10 @@ class AddEntryToServerTestCase(unittest.TestCase):
         response = self.server.run("peace")
         self.assertIn("peace", response["error"])
 
+    def test_get_categories(self):
+        response = self.server.run("categories", pocket=self.pocket)
+        self.assertListEqual(response["categories"], ["outdoors"])
+
 
 class RecurrentEntryServerTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #233.

- Add pocket.get_categories
- Improve server test class
- Enable running "categories" command in server
- Store and read category cache for CLI completion
- Store category cache as newline-separated strings
- Add error handling
